### PR TITLE
Fix Graphviz pointer type

### DIFF
--- a/imgui_graphnode_internal.cpp
+++ b/imgui_graphnode_internal.cpp
@@ -276,7 +276,7 @@ ImVec2 ImGuiGraphNode_BezierVec2(ImVec2 const * points, int count, float x)
 void ImGuiGraphNodeRenderGraphLayout(ImGuiGraphNodeContextCache & cache)
 {
     char * data = nullptr;
-    unsigned int size = 0;
+    size_t size = 0;
     char const * const engine = ImGuiGraphNode_GetEngineNameFromLayoutEnum(cache.layout);
     int ok = 0;
 


### PR DESCRIPTION
```
/home/aru/code/fdtd-lucuma/build/_deps/imgui-graphnode-src/imgui_graphnode_internal.cpp:289:10: error: no matching function for call to 'gvRenderData'
  289 |     ok = gvRenderData(g_ctx.gvcontext, g_ctx.gvgraph, "plain", &data, &size);
      |          ^~~~~~~~~~~~
/usr/include/graphviz/gvc.h:98:13: note: candidate function not viable: no known conversion from 'unsigned int *' to 'size_t *' (aka 'unsigned long *') for 5th argument
   98 | GVC_API int gvRenderData(GVC_t *gvc, graph_t *g, const char *format,
      |             ^
   99 |                          char **result, size_t *length);
      |                                         ~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```